### PR TITLE
Add simple console interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # fuckiddngbot
+## Console Tool
+
+This repository includes a simple interactive console built with Python's `curses` module. You can run it to execute shell commands inside a text user interface.
+
+### Running
+
+```
+python3 console_tool.py
+```
+
+Type commands and press Enter to execute. Type `exit` or `quit` to leave the console.

--- a/console_tool.py
+++ b/console_tool.py
@@ -1,0 +1,39 @@
+import curses
+import subprocess
+
+
+def main(stdscr):
+    curses.curs_set(1)
+    stdscr.clear()
+    max_y, max_x = stdscr.getmaxyx()
+    input_win = curses.newwin(1, max_x, max_y - 1, 0)
+    output_win = curses.newwin(max_y - 1, max_x, 0, 0)
+    output_lines = []
+
+    while True:
+        output_win.clear()
+        start_line = max(0, len(output_lines) - (max_y - 1))
+        for i, line in enumerate(output_lines[start_line:], 0):
+            output_win.addstr(i, 0, line[:max_x-1])
+        output_win.refresh()
+        input_win.clear()
+        input_win.refresh()
+        curses.echo()
+        command = input_win.getstr(0, 0).decode('utf-8')
+        curses.noecho()
+        if command in ['exit', 'quit']:
+            break
+        if command:
+            try:
+                result = subprocess.run(command, shell=True, text=True, capture_output=True)
+                output_lines.extend((result.stdout + result.stderr).splitlines())
+            except Exception as e:
+                output_lines.append(f"Error: {e}")
+
+
+def run():
+    curses.wrapper(main)
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- create `console_tool.py` with a curses-based interface
- document how to run the console tool

## Testing
- `python3 console_tool.py` *(fails: curses requires a TTY)*

------
https://chatgpt.com/codex/tasks/task_e_6843847c7a988327923cc427da3291c9